### PR TITLE
Make base model tenant-isolated resources

### DIFF
--- a/server/internal/server/models_test.go
+++ b/server/internal/server/models_test.go
@@ -63,16 +63,11 @@ func TestDeleteModel_BaseModel(t *testing.T) {
 	st, tearDown := store.NewTest(t)
 	defer tearDown()
 
-	srv := New(st)
-	isrv := NewInternal(st, "models")
-	ctx := context.Background()
-	_, err := isrv.CreateBaseModel(ctx, &v1.CreateBaseModelRequest{
-		Id:            "m0",
-		Path:          "path",
-		GgufModelPath: "gguf-path",
-	})
+	_, err := st.CreateBaseModel("m0", "path", "gguf-path", defaultTenantID)
 	assert.NoError(t, err)
 
+	srv := New(st)
+	ctx := context.Background()
 	_, err = srv.DeleteModel(ctx, &v1.DeleteModelRequest{
 		Id: "m0",
 	})
@@ -99,7 +94,7 @@ func TestGetAndListModels(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	_, err = st.CreateBaseModel(baseModelID, "path", "gguf-path")
+	_, err = st.CreateBaseModel(baseModelID, "path", "gguf-path", defaultTenantID)
 	assert.NoError(t, err)
 
 	srv := New(st)
@@ -129,12 +124,12 @@ func TestInternalGetModel(t *testing.T) {
 	st, tearDown := store.NewTest(t)
 	defer tearDown()
 
-	_, err := st.CreateBaseModel("model0", "path", "gguf-path")
+	_, err := st.CreateBaseModel("model0", "path", "gguf-path", fakeTenantID)
 	assert.NoError(t, err)
 
 	_, err = st.CreateModel(store.ModelSpec{
 		ModelID:        "model1",
-		TenantID:       "tenant1",
+		TenantID:       fakeTenantID,
 		OrganizationID: "o0",
 		ProjectID:      defaultProjectID,
 		IsPublished:    true,
@@ -281,9 +276,4 @@ func TestBaseModels(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, "path", getResp.Path)
-
-	listResp, err = srv.ListBaseModels(ctx, &v1.ListBaseModelsRequest{})
-	assert.NoError(t, err)
-	assert.Len(t, listResp.Data, 1)
-	assert.Equal(t, modelID, listResp.Data[0].Id)
 }

--- a/server/internal/store/base_model_test.go
+++ b/server/internal/store/base_model_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	gerrors "github.com/llm-operator/common/pkg/gormlib/errors"
 	"github.com/stretchr/testify/assert"
 	"gorm.io/gorm"
 )
@@ -13,25 +14,50 @@ func TestBaseModel(t *testing.T) {
 	defer tearDown()
 
 	const (
-		modelID = "m0"
+		modelID  = "m0"
+		tenantID = "t0"
 	)
 
-	_, err := st.GetBaseModel(modelID)
+	_, err := st.GetBaseModel(modelID, tenantID)
 	assert.Error(t, err)
 	assert.True(t, errors.Is(err, gorm.ErrRecordNotFound))
 
-	_, err = st.CreateBaseModel(modelID, "path", "gguf_model_path")
+	_, err = st.CreateBaseModel(modelID, "path", "gguf_model_path", tenantID)
 	assert.NoError(t, err)
 
-	gotM, err := st.GetBaseModel(modelID)
+	gotM, err := st.GetBaseModel(modelID, tenantID)
 	assert.NoError(t, err)
 	assert.Equal(t, modelID, gotM.ModelID)
 	assert.Equal(t, "path", gotM.Path)
 
-	gotMs, err := st.ListBaseModels()
+	_, err = st.GetBaseModel(modelID, "different_tenant")
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, gorm.ErrRecordNotFound))
+
+	gotMs, err := st.ListBaseModels(tenantID)
 	assert.NoError(t, err)
 	assert.Len(t, gotMs, 1)
 	assert.Equal(t, modelID, gotMs[0].ModelID)
 	assert.Equal(t, "path", gotMs[0].Path)
 	assert.Equal(t, "gguf_model_path", gotMs[0].GGUFModelPath)
+
+	gotMs, err = st.ListBaseModels("different_tenant")
+	assert.NoError(t, err)
+	assert.Empty(t, gotMs)
+}
+
+func TestBaseModel_UniqueConstraint(t *testing.T) {
+	st, tearDown := NewTest(t)
+	defer tearDown()
+
+	_, err := st.CreateBaseModel("m0", "path", "gguf_model_path", "t0")
+	assert.NoError(t, err)
+
+	_, err = st.CreateBaseModel("m0", "path", "gguf_model_path", "t0")
+	assert.Error(t, err)
+	assert.True(t, gerrors.IsUniqueConstraintViolation(err))
+
+	_, err = st.CreateBaseModel("m1", "path", "gguf_model_path", "t0")
+	assert.NoError(t, err)
+
 }


### PR DESCRIPTION
It's better to allow different tenants to have different base models as they will be stored in different locations.