### PR TITLE
Shorten the target port name

### DIFF
--- a/deployments/server/templates/deployment.yaml
+++ b/deployments/server/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         - name: grpc
           containerPort: {{ .Values.grpcPort }}
           protocol: TCP
-        - name: worker-service-grpc
+        - name: ws-grpc
           containerPort: {{ .Values.workerServiceGrpcPort }}
           protocol: TCP
         volumeMounts:

--- a/deployments/server/templates/service.yaml
+++ b/deployments/server/templates/service.yaml
@@ -43,9 +43,9 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-  - name: grpc
+  - name: ws-grpc
     port: {{ .Values.internalGrpcPort }}
     protocol: TCP
-    targetPort: worker-service-grpc
+    targetPort: ws-grpc
   selector:
     {{- include "model-manager-server.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
We hit the 15 chars limit.

https://stackoverflow.com/questions/73330773/is-there-any-way-to-disable-or-increase-port-name-length-in-kubernetes