### PR TITLE
Fix model upload path

### DIFF
--- a/loader/internal/loader/loader.go
+++ b/loader/internal/loader/loader.go
@@ -221,8 +221,8 @@ func (l *L) downloadAndUploadModel(ctx context.Context, modelID string) (string,
 	}
 
 	toKey := func(path string) string {
-		// Remove the tmpdir path from the path. We need tmpDir[2:] since the path starts with "./" while 'path' omits it.
-		relativePath := strings.TrimPrefix(path, tmpDir[2:])
+		// Remove the tmpdir path from the path.
+		relativePath := strings.TrimPrefix(path, tmpDir)
 		return filepath.Join(l.objectStorePathPrefix, modelID, relativePath)
 	}
 

--- a/loader/internal/loader/loader_test.go
+++ b/loader/internal/loader/loader_test.go
@@ -35,7 +35,7 @@ func TestLoadBaseModel(t *testing.T) {
 		s3Client,
 		mc,
 	)
-	ld.tmpDir = "./"
+	ld.tmpDir = "/tmp"
 	err := ld.loadBaseModel(context.Background(), "google/gemma-2b")
 	assert.NoError(t, err)
 


### PR DESCRIPTION
Files are uploaded to <model-path/tmp/base-model<random-number/<file> after when we changed the tmp dir from "./" to "/tmp".