### PR TITLE
Add GGUF as a model format if the formats is empty

### DIFF
--- a/server/internal/server/models.go
+++ b/server/internal/server/models.go
@@ -346,6 +346,11 @@ func (s *WS) GetBaseModelPath(
 		return nil, status.Errorf(codes.Internal, "unmarshal model formats: %s", err)
 	}
 
+	// Add GGUF as format if GGUF model path is set (for backward compatibility).
+	if m.GGUFModelPath != "" && len(formats) == 0 {
+		formats = append(formats, v1.ModelFormat_MODEL_FORMAT_GGUF)
+	}
+
 	return &v1.GetBaseModelPathResponse{
 		Path:          m.Path,
 		Formats:       formats,

--- a/server/internal/server/models_test.go
+++ b/server/internal/server/models_test.go
@@ -281,4 +281,5 @@ func TestBaseModels(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, "path", getResp.Path)
+	assert.ElementsMatch(t, []v1.ModelFormat{v1.ModelFormat_MODEL_FORMAT_GGUF}, getResp.Formats)
 }


### PR DESCRIPTION
This is needed for backward compatibility.